### PR TITLE
Several enhancements of regenerate.sh script

### DIFF
--- a/regenerate.sh
+++ b/regenerate.sh
@@ -33,6 +33,7 @@ strip_comments() {
 
 # checks whether image name lives here
 lives_here() {
+  [ -v REGENERATE_LOCALS ] && return 1
   grep -e "^[[:space:]]*$1[[:space:]]*\$" config.local
   return $?
 }

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -77,6 +77,7 @@ refresh_remotes() {
     image=$(echo "$entry" | awk '{print $1}')
     repo=$(echo "$entry" | awk '{print $2}')
     path=$(echo "$entry" | awk '{print $3}')
+    branch=$(echo "$entry" | awk '{print $4}')
     lives_here "$image" && continue
 
     # remove old content if exists
@@ -85,6 +86,7 @@ refresh_remotes() {
     # clone remote repo and copy content
     workingdir=$(mktemp -d /tmp/remote-repo-XXXXXX)
     git clone $repo $workingdir
+    [ -n "$branch" ] && git checkout "$branch"
     cp -r $workingdir/$path $image
 
     # some repositories contain more Dockerfiles in the repository, try to use the correct one

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -28,7 +28,7 @@ set -ex
 
 # removes comments and empty lines from a file
 strip_comments() {
-  cat $1 | sed -e 's:#.*$::g' -e '/^[[:space:]]*$/d'
+  cat $@ | sed -e 's:#.*$::g' -e '/^[[:space:]]*$/d'
 }
 
 # checks whether image name lives here
@@ -72,7 +72,7 @@ refresh_generated() {
 # 3. adds new content from the remote repository into this repository
 # It also renames Dockerfile.rhel{6,7} to Dockerfile
 refresh_remotes() {
-  strip_comments config.remote | while read entry ; do
+  strip_comments config.remote* | while read entry ; do
     # parse the entry
     image=$(echo "$entry" | awk '{print $1}')
     repo=$(echo "$entry" | awk '{print $2}')

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -93,8 +93,8 @@ refresh_remotes() {
     cp -r $workingdir/$path $image
 
     # some repositories contain more Dockerfiles in the repository, try to use the correct one
-    [[ $image =~ rhel7 ]] && [ -f $image/Dockerfile.rhel7 ] && mv -f $image/Dockerfile.rhel7 $image/Dockerfile
-    [[ $image =~ rhel6 ]] && [ -f $image/Dockerfile.rhel6 ] && mv -f $image/Dockerfile.rhel6 $image/Dockerfile
+    [[ $image =~ rhel7 ]] && [ -f $image/Dockerfile.rhel7 ] && [ ! -L $image/Dockerfile.rhel7 ] && mv -f $image/Dockerfile.rhel7 $image/Dockerfile
+    [[ $image =~ rhel6 ]] && [ -f $image/Dockerfile.rhel6 ] && [ ! -L $image/Dockerfile.rhel6 ] && mv -f $image/Dockerfile.rhel6 $image/Dockerfile
 
     # produce some sane info about where the image comes from
     echo "This image was pulled from $repo (subdirectory $path) at `date -u`." >$image/README.generation

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -91,6 +91,7 @@ refresh_remotes() {
     [ -n "$branch" ] && git checkout "$branch"
     popd
     cp -r $workingdir/$path $image
+    rm -rf $image/.git
 
     # some repositories contain more Dockerfiles in the repository, try to use the correct one
     [[ $image =~ rhel7 ]] && [ -f $image/Dockerfile.rhel7 ] && [ ! -L $image/Dockerfile.rhel7 ] && mv -f $image/Dockerfile.rhel7 $image/Dockerfile

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -87,7 +87,9 @@ refresh_remotes() {
     # clone remote repo and copy content
     workingdir=$(mktemp -d /tmp/remote-repo-XXXXXX)
     git clone $repo $workingdir
+    pushd "$workingdir"
     [ -n "$branch" ] && git checkout "$branch"
+    popd
     cp -r $workingdir/$path $image
 
     # some repositories contain more Dockerfiles in the repository, try to use the correct one

--- a/regenerate.sh
+++ b/regenerate.sh
@@ -113,4 +113,4 @@ refresh_generated
 
 refresh_remotes
 
-
+echo 'Done.'


### PR DESCRIPTION
Add help, some new options to list what we track, add protection from unwanted regeneration, etc..
Report success in the end.
Do not copy .git directory from remote
Don't do anything with Dockerfile.rhel7 if it is a symlink
Go to the repository directory before calling git checkout
Add possibility to ignore protection of local repos
Allow to use branch in the remotes config
Allow to have more remote config files
