### PR TITLE
line 197 defaults to standard port, adding usage of CONTAINER_PORT

### DIFF
--- a/rhel7.rh-mongodb32/root/usr/share/container-scripts/mongodb/common.sh
+++ b/rhel7.rh-mongodb32/root/usr/share/container-scripts/mongodb/common.sh
@@ -194,7 +194,7 @@ function mongo_create_admin() {
 
   # Set admin password
   local js_command="db.createUser({user: 'admin', pwd: '${MONGODB_ADMIN_PASSWORD}', roles: ['dbAdminAnyDatabase', 'userAdminAnyDatabase' , 'readWriteAnyDatabase','clusterAdmin' ]});"
-  if ! mongo admin ${1:-} --host ${2:-"localhost"} --eval "${js_command}"; then
+  if ! mongo admin ${1:-} --host ${2:-"localhost"} --port "${CONTAINER_PORT}" --eval "${js_command}"; then
     echo "=> Failed to create MongoDB admin user."
     exit 1
   fi


### PR DESCRIPTION
If you happen to change the container port, due to the lack of `--port <port_number>` on line 197, the build will fail. Simply adding in `--post "${CONTAINER_PORT}"` to use the CONTAINER_PORT variable that is already in place.
