### PR TITLE
Improvements and documentation for nginx s2i support

### DIFF
--- a/rhel7.rh-nginx18/README.md
+++ b/rhel7.rh-nginx18/README.md
@@ -1,13 +1,27 @@
 Nginx 1.8 server and a reverse proxy server docker image
 ========================================================
 
-The `centos/rh-nginx-18-centos7` image provides an nginx 1.8 server and a reverse proxy server. The image can be used as a base image for other applications based on nginx 1.8 web server.
+The `rhscl/nginx-18-rhel7` image provides an nginx 1.8 server and a reverse proxy server. The image can be used as a base image for other applications based on nginx 1.8 web server.
 
 
-To pull the `centos/rh-nginx-18-centos7` image, run the following command as root:
+To pull the `rhscl/nginx-18-rhel7` image, run the following command as root:
 ```
-docker pull centos/rh-nginx-18-centos7
+docker pull rhscl/nginx-18-rhel7
 ```
+
+S2I build support
+-------------
+Nginx configuration can be extended using S2I tool.
+S2I build folder structure:
+
+|    Folder name         |    Description                            |
+| :--------------------- | ----------------------------------------- |
+|  ./nginx-cfg/*.conf    | Should contain all nginx configuration we want to include into image |
+|  ./src/                | Should contain nginx application source code |
+
+Execution:
+
+        s2i build --context-dir=. rhscl/nginx-18-rhel7 your-image-name
 
 
 Configuration

--- a/rhel7.rh-nginx18/s2i/bin/assemble
+++ b/rhel7.rh-nginx18/s2i/bin/assemble
@@ -3,7 +3,7 @@
 set -e
 
 echo "---> Installing application source"
-cp -Rf /tmp/src/. ./
+cp -Rf ./src ./
 
 if [ -d ./nginx-cfg ]; then
   echo "---> Copying nginx configuration files..."

--- a/rhel7.rh-nginx18/s2i/bin/usage
+++ b/rhel7.rh-nginx18/s2i/bin/usage
@@ -8,7 +8,7 @@ To use it, install S2I: https://github.com/openshift/source-to-image
 
 Sample invocation:
 
-s2i build https://github.com/openshift/sti-perl.git --context-dir=5.16/test/sample-test-app/ openshift/perl-516-${DISTRO}7 perl-sample-app
+s2i build . --context-dir=. rhscl/nginx-18-rhel7 your-image-name
 
 You can then run the resulting image via:
 docker run -p 8080:8080 perl-sample-app


### PR DESCRIPTION
# Motivation

Added some documentation and s2i improvements to reduce confusion for image endusers. Changed the way source code is fetched to use local context (rather than fixed /tmp path)

# Notes 

It seems that there is no centos version of the image for nginx18. 
Can I create this basing  on changes we done bellow?